### PR TITLE
added exclude_outofrange functionality for assessment/testing

### DIFF
--- a/R/analyze-data.R
+++ b/R/analyze-data.R
@@ -34,7 +34,7 @@
 
 wt_summarise_cam <- function(detect_data, raw_data, time_interval = "day",
                              variable = "detections", output_format = "wide",
-                             species_col = species_common_name, effort_data = NULL,
+                             species_col = species_common_name, effort_data = NULL, exclude_outofrange = FALSE,
                              project_col = project_id, station_col = location,
                              date_time_col = image_date_time,
                              start_col = start_date, end_col = end_date,
@@ -80,34 +80,65 @@ wt_summarise_cam <- function(detect_data, raw_data, time_interval = "day",
 
   # Parse the raw or effort data to get time ranges for each camera deployment.
   if (!rlang::is_missing(raw_data)) {
-    x <- raw_data |>
-      mutate(image_date_time = ymd_hms({{date_time_col}})) |>
-      group_by({{project_col}}, .data[[station_col]]) |>
-      summarise(start_date = as.Date(min(image_date_time)),
-                end_date = as.Date(max(image_date_time))) |>
-      ungroup()
+    ## if exclude_outofrange == FALSE then include all operations days between deployment and check
+    if (exclude_outofrange == FALSE) {
+      x <- raw_data |>
+        mutate(image_date_time = ymd_hms(
+          #date work around due to ymd_hms failing to parse some times when 00:00:00
+          format(
+            as.POSIXct({{ date_time_col }}),
+            format = "%Y-%m-%d %T %Z"
+          )
+        )) |>
+        group_by({{ project_col }}, .data[[station_col]]) |>
+        summarise(
+          start_date = as.Date(min(image_date_time)),
+          end_date = as.Date(max(image_date_time))
+        ) |>
+        ungroup()
+
+      # Expand the time ranges into individual days of operation (smallest unit)
+      x <- x |>
+        group_by({{ project_col }}, .data[[station_col]]) |>
+        mutate(day = list(seq.Date(start_date, end_date, by = "day"))) |>
+        unnest(day) |>
+        mutate(year = year(day)) |>
+        select({{ project_col }}, .data[[station_col]], year, day)
 
     if (any(c(is.na(x$start_date), is.na(x$end_date)))) {
       message("Parsing of image date time produced NAs, these will be dropped")
       x <- drop_na(x)
     }
+    ## if exclude_outofrange == TRUE then include remove periods of non operation
+    if (exclude_outofrange == TRUE) {
+      x <- raw_data |>
+        mutate(image_date_time = ymd_hms(
+          #date work around due to ymd_hms failing to parse some times when 00:00:00
+          format(
+            as.POSIXct({{ date_time_col }}),
+            format = "%Y-%m-%d %T %Z"
+          )
+        )) |>
+        group_by({{ project_col }}, .data[[station_col]]) |>
+        arrange(image_date_time) %>%
+        mutate(period = rep(seq_along(rle(image_fov)$lengths), rle(image_fov)$lengths)) %>%
+        filter(image_fov == "WITHIN") %>%
+        group_by({{ project_col }}, .data[[station_col]], period) |>
+        summarise(
+          start_date = as.Date(min(image_date_time)),
+          end_date = as.Date(max(image_date_time))
+        ) |>
+        ungroup()
 
-  } else {
-    x <- effort_data |>
-      select(project_id = {{project_col}},
-             location = .data[[station_col]],
-             start_date = {{start_col}},
-             end_date = {{end_col}}) |>
-      ungroup()
+      # Expand the time ranges into individual days of operation (smallest unit)
+      x <- x |>
+        group_by({{ project_col }}, .data[[station_col]], period) |>
+        mutate(day = list(seq.Date(start_date, end_date, by = "day"))) |>
+        unnest(day) |>
+        mutate(year = year(day)) |>
+        select({{ project_col }}, .data[[station_col]], year, day)
+    }
   }
-
-  # Expand the time ranges into individual days of operation (smallest unit)
-  x <- x |>
-    group_by({{project_col}}, .data[[station_col]]) |>
-    mutate(day = list(seq.Date(start_date, end_date, by = "day"))) |>
-    unnest(day) |>
-    mutate(year = year(day))  |>
-    select({{project_col}}, .data[[station_col]], year, day)
 
   # Based on the desired timeframe, assess when each detection occurred
   if (time_interval == "day" | time_interval == "full") {

--- a/R/analyze-data.R
+++ b/R/analyze-data.R
@@ -104,10 +104,6 @@ wt_summarise_cam <- function(detect_data, raw_data, time_interval = "day",
         unnest(day) |>
         mutate(year = year(day)) |>
         select({{ project_col }}, .data[[station_col]], year, day)
-
-    if (any(c(is.na(x$start_date), is.na(x$end_date)))) {
-      message("Parsing of image date time produced NAs, these will be dropped")
-      x <- drop_na(x)
     }
     ## if exclude_outofrange == TRUE then include remove periods of non operation
     if (exclude_outofrange == TRUE) {
@@ -138,7 +134,13 @@ wt_summarise_cam <- function(detect_data, raw_data, time_interval = "day",
         mutate(year = year(day)) |>
         select({{ project_col }}, .data[[station_col]], year, day)
     }
-  }
+
+    if (any(c(is.na(x$start_date), is.na(x$end_date)))) {
+      message("Parsing of image date time produced NAs, these will be dropped")
+      x <- drop_na(x)
+    }
+    }
+
 
   # Based on the desired timeframe, assess when each detection occurred
   if (time_interval == "day" | time_interval == "full") {


### PR DESCRIPTION
Response to issue #62. Added functionality to remove days from effort when camera fov is obscured. Open to alternate approaches. I tested it on a few different ABMI and my own WT datasets and seems to work. The overall change in results are modest for the datasets I looked at, 0-15% change in average daily detection rate, but overall difference will depend on how many days cams spend out of FOV.

```
eh14_raw <- wt_download_report(
  project_id = 798, 
  sensor_id = "CAM",
  report = "main", 
  weather_cols = FALSE
)


eh14_detections <- wt_ind_detect(
  x = eh14_raw, 
  threshold = 30,
  units = "minutes",
  remove_human = TRUE, 
  remove_domestic = TRUE 
)


eh14_summarised <- wt_summarise_cam(
  # Supply your detection data
  detect_data = eh14_detections,
  # Supply your raw image data
  raw_data = eh14_raw,
  # Now specify the time interval you're interested in 
  time_interval = "week",
  # What variable are you interested in?
  variable = "counts",
  # Your desired output format (wide or long) 
  output_format = "long",
  exclude_outofrange=FALSE
)
without_effort <-mean(eh14_summarised$value/eh14_summarised$n_days_effort)


eh14_summarised_exclude <- wt_summarise_cam(
  # Supply your detection data
  detect_data = eh14_detections,
  # Supply your raw image data
  raw_data = eh14_raw,
  # Now specify the time interval you're interested in 
  time_interval = "week",
  # What variable are you interested in?
  variable = "counts",
  # Your desired output format (wide or long) 
  output_format = "long",
  exclude_outofrange=TRUE
)
with_effort <- mean(eh14_summarised_exclude$value/eh14_summarised_exclude$n_days_effort)


((with_effort-without_effort)/without_effort)*100
#=1.2% lower
```


