### PR TITLE
groom classifier vignette for 2.0

### DIFF
--- a/vignettes/classifiers-tutorial.Rmd
+++ b/vignettes/classifiers-tutorial.Rmd
@@ -27,12 +27,17 @@ Recent advances in deep learning have led to the development of neural network m
 
 ## Classifiers
 
-Classifier scores can be converted to species detections by setting a threshold (e.g., 0.8) above which to consider a species present within a given spectrogram @wood2024guidelines. False positives can still occur at high score thresholds, so often verification by a human observer is still necessary.
+The WildTrax 2.0 release (2025) runs inference with two classifiers on recordings that are uploaded to the system.
 
+[BirdNET](https://birdnet.cornell.edu/) is a deep learning classifier developed by the Cornell Lab of Ornithology that is trained to classify more than 6,000 of the world's most common bird species, including most North American bird species @kahl2021birdnet.
 
-[BirdNET](https://birdnet.cornell.edu/) is a deep learning classifier developed by the Cornell Lab of Ornithology that is trained to classify more than 6,000 of the world's most common bird species, including most North American bird species @kahl2021birdnet. The model converts audio recordings into windows of spectrograms and outputs a probability score for each species in each one. The WildTrax 2.0 release (2025) is accompanied by the introduction of a new deep learning model, HawkEars (@huus2025hawkears), that can classify many of Canada's most common bird species. HawkEars is implemented in the same fashion as BirdNET so that users will also be able to download a report and use the same set of `wildrtrax` functions demonstrated above on it. HawkEars is also freely available from [Github](https://github.com/jhuus/HawkEars). Initial tests of HawkEars on the same expert dataset as above suggest it performs much better than BirdNET for Canadian species, with more than double the recall and higher precision at score thresholds above 50. 
+[HawkEars](https://github.com/jhuus/HawkEars) is also a deep learning classifier that is specifically trained to classify Canada's bird species. HawkEars is implemented in the same fashion as BirdNET so that users will also be able to download a report. Initial tests of HawkEars on the same expert dataset as above suggest it performs much better than BirdNET for Canadian species, with more than double the recall and higher precision at score thresholds above 0.50 (@huus2025hawkears). 
+
+Both classifiers are run in WildTrax 2.0 without location or date filtering turned on. The minimum score threshold is 0.20 for BirdNET version 2.1 and 0.30 for HawkEars version 1.0.8.
 
 ## Classifier performance
+
+For each window (typically 3 seconds) of an acoustic recording, the classifier outputs a score, which is a unitless, numeric expression of the model's "confidence" in its prediction, scaled from 0 to 1. Scores cannot be directly interpreted as probabilities unless they have been scaled for a particular dataset. Classifier scores can be converted to species detections by setting a threshold (e.g., 0.8) above which to consider a species present within a given spectrogram @wood2024guidelines. False positives can still occur at high score thresholds, so often verification by a human observer is still necessary.
 
 Choosing a score threshold will depend on the goals of the project; however, threshold choice is a trade-off between false positives (i.e., incorrect classifications) and false negatives (i.e., missed detections; see @priyadarshani2018automated, @knight_2017). Choosing a high score threshold will minimize false positives, but will also result in false negatives. Choosing a low score threshold will minimize false negatives but will result in many false positives. The proportion of false positives at a given score threshold is typically measured by precision:
 
@@ -49,56 +54,6 @@ The threshold-agnostic performance of a classifier is then typically evaluated a
 F-score is a combination of precision and recall and can also used to select a score threshold by selecting the peak value.
 
 $Fscore = \frac{2 * precision* recall}{precision + recall}$
-
-ABMI has evaluated BirdNET with a dataset of 623 3-minute recordings. All species were annotated in each minute of each recording by our top expert listeners and further groomed for false positives and negatives. The dataset was selected to include at least 10 recordings with detections of the most common 203 Canadian bird species. Recordings were primarily sourced from Alberta and Ontario to include variation in dialect. We evaluated BirdNET by running it using the local eBird occurrence data for each recording and comparing results with our expert dataset and pooling the total detections across species per minute of recording to calculate overall precision, recall, and F-score.
-
-Precision ranged from 0.36 at a score threshold of 0.10 to 0.94 at a score threshold of 0.99 (Figure 1). Recall ranged from 0.01 at a score threshold of 0.99 to 0.36 of 0.1  F-score was similarly low, ranging from 0.03 at a score threshold of 0.01 to 0.36 at a score threshold of 0.99. Neither the precision-recall curve nor the plot of F-score relative to score threshold showed a typical concave down curve shape, suggesting that a low score threshold of 0.10 would be best to optimize trade-offs between precision and recall.
-
-```{r, eval=T, include=F, echo=F, message=F, warning=F}
-
-tmp_file <- tempfile(fileext = ".csv")
-
-request("https://raw.githubusercontent.com/ABbiodiversity/wildRtrax-assets/main/ExpertData_PR_Total.csv") |>
-  req_perform(path = tmp_file)
-
-# Read and filter
-dat <- read_csv(tmp_file) |>
-  filter(classifier == "BirdNET", thresh >= 0.1)
-
-```
-
-```{r, eval=T, include=T, echo=F, message=F, warning=F}
-library(ggplot2)
-
-ggplot(dat) +
-  geom_line(aes(x=thresh, y=f), size=1.5) +
-  xlab("Score threshold") +
-  ylab("F-score") +
-  xlim(c(0.1, 1)) +
-  ylim(c(0, 1)) +
-  theme_bw()
-
-```
-
-```{r, eval=T, include=T, echo=F, message=F, warning=F}
-Sys.setenv(WT_USERNAME = 'guest', WT_PASSWORD = 'Apple123')
-wt_auth()
-
-data <- wt_download_report(620, 'ARU', c('main','ai'))
-
-eval <- wt_evaluate_classifier(data, resolution = "task", remove_species = TRUE, species = NULL, thresholds = c(0.01,0.99))
-
-ggplot(eval) +
-  geom_smooth(aes(x=recall, y=precision, colour=classifier), linewidth=1.5) +
-  xlab("Recall") +
-  ylab("Precision") +
-  xlim(0,1) +
-  ylim(0,1) +
-  theme_bw()
-
-```
-
-WildTrax uses both BirdNET and HawkEars to automatically classify species in all recordings that are uploaded to the system. The sensitivity for BirdNET is set at 1.5 to reduce the probability of false positives and the score threshold is set low at 0.1 to allow users to set higher thresholds as needed. The list of species is filtered by eBird occurrence data for the week of recording, but not by location.
 
 ## Evaluating
 
@@ -274,7 +229,7 @@ ggplot(occupied_wcsp) +
 
 ## Other applications
 
-Visit the [BirdNET Github repository](https://github.com/birdnet-team/BirdNET-Analyzer) and HawkEars repository to run or modify these classifiers on your own computer. The decision to pursue other applications should be made with the effect of a classifier's low recall rate in mind:
+Visit the [BirdNET Github repository](https://github.com/birdnet-team/BirdNET-Analyzer) and [HawkEars Github repository](https://github.com/jhuus/HawkEars) to run or modify these classifiers on your own computer. The decision to pursue other applications should be made with the effect of a classifier's low recall rate in mind:
 
 1. With presence / absence data, a classifier is unlikely to be reliably to confirm absences due to the low recall.
 


### PR DESCRIPTION
Removed evaluation results in classifier section (they're published now), groomed descriptions of BirdNET & HawkEars, their implementation in 2.0, and the description of scores & score thresholds